### PR TITLE
Plotting: reduced space between subplots

### DIFF
--- a/anticipy/forecast_plot.py
+++ b/anticipy/forecast_plot.py
@@ -206,7 +206,9 @@ def _plotly_forecast_create(df_fcast, subplots, sources, nrows, ncols,
         fig = tools.make_subplots(rows=nrows,
                                   cols=ncols,
                                   subplot_titles=list(titles),
-                                  print_grid=False)
+                                  print_grid=False,
+                                  horizontal_spacing=0.03,
+                                  vertical_spacing=0.05)
     else:
         fig = tools.make_subplots(rows=nrows, cols=ncols, print_grid=False)
 


### PR DESCRIPTION
I think it looks much better after the change, but I'm open to suggestions. Let me know if you find that it breaks any of your plots.

Before:
![plotly_before](https://user-images.githubusercontent.com/2239771/47438001-81ab6500-d7a1-11e8-8e14-1469141ab0b8.png)

After:
![plotly_after](https://user-images.githubusercontent.com/2239771/47438009-853eec00-d7a1-11e8-94b1-a35cdd308344.png)
