### PR TITLE
feature #100; UK Calendar

### DIFF
--- a/anticipy/forecast_models.py
+++ b/anticipy/forecast_models.py
@@ -1477,6 +1477,7 @@ def get_f_dummy_from_list(list_check):
     # Generate a f_dummy function that defines a dummy variable, can be used
     # for dummy models
     s_check = pd.Series(list_check)
+    assert s_check.size, 'Input list cannot be empty'
     if pd.api.types.is_numeric_dtype(s_check):
         list_check_numeric = s_check
 
@@ -1539,10 +1540,10 @@ class UKCalendar(AbstractHolidayCalendar):
         GoodFriday,
         EasterMonday,
         # Early May Bank Holiday - first Monday in May
-        # Spring Bank Holiday - Last Monday in May - Same as US Memorial Day
         Holiday('Early May Bank Holiday', month=5, day=1,
                 offset=DateOffset(weekday=MO(1))
                 ),
+        # Spring Bank Holiday - Last Monday in May
         Holiday('Spring Bank Holiday', month=5, day=31,
                 offset=DateOffset(weekday=MO(-1))
                 ),
@@ -1554,6 +1555,32 @@ class UKCalendar(AbstractHolidayCalendar):
 
 
 def get_model_from_calendar(calendar):
+    """
+    Create a ForecastModel based on a pandas Calendar.
+
+    :param calendar:
+    :type calendar: pandas.tseries.AbstractHolidayCalendar
+    :return: model based on the input calendar
+    :rtype: ForecastModel
+
+    In pandas, Holidays and calendars provide a simple way to define
+    holiday rules, to be used in any analysis that requires a predefined
+    set of holidays. This function converts a Calendar object into a
+    ForecastModel that assigns a parameter to each calendar rule.
+
+    As an example, a Calendar with 1 rule defining Christmas dates
+    generates a model with a single parameter, which
+    determines the amount added/multiplied to samples falling on Christmas.
+    A calendar with 2 rules for Christmas and New Year will have two parameters
+    - the first one applying to samples in Christmas, and the second
+    one applying to samples in New Year.
+
+    Usage::
+
+        from pandas.tseries.holiday import USFederalHolidayCalendar
+        model_calendar = get_model_from_calendar(USFederalHolidayCalendar())
+
+    """
     l_model_dummy = [get_model_dummy(rule.name, rule)
                      for rule in calendar.rules]
     assert (len(l_model_dummy)), 'Need 1+ rules in calendar'
@@ -1583,6 +1610,56 @@ def get_model_from_calendar(calendar):
 model_ukcalendar = get_model_from_calendar(UKCalendar())
 model_uscalendar = get_model_from_calendar(USFederalHolidayCalendar())
 
+
+def get_model_from_datelist(name=None, *args):
+    """
+    Create a ForecastModel based on one or more lists of dates.
+
+    :param name: Model name
+    :type name: str
+    :param args: Each element in args is a list of dates.
+    :type args:
+    :return: model based on the input lists of dates
+    :rtype: ForecastModel
+
+    Usage::
+
+        model_datelist1=get_model_from_date_list('datelist1',
+                                                 [date1, date2, date3])
+        model_datelists23 = get_model_from_date_list('datelists23',
+                                                [date1, date2], [date3, date4])
+
+    In the example above, model_datelist1 will have one parameter, which
+    determines the amount added/multiplied to samples with dates matching
+    either date1, date2 or date3. model_datelists23 will have two parameters
+    - the first one applying to samples in date1 and date2, and the second
+    one applying to samples in date 3 and date4
+
+    """
+    l_model_dummy = [get_model_dummy('model_dummy', pd.to_datetime(l_date))
+                     for l_date in args]
+    assert (len(l_model_dummy)), 'Need 1+ lists of dates'
+    f_model_prod = np.prod(l_model_dummy)
+    f_model_sum = np.sum(l_model_dummy)
+
+    def _f_init_params_date_list(
+            a_x=None, a_y=None, a_date=None, is_mult=False):
+        if is_mult:
+            return np.ones(len(l_model_dummy))
+        else:
+            return np.zeros(len(l_model_dummy))
+
+    def _f_model_date_list(a_x, a_date, params, is_mult=False, **kwargs):
+        f_all_dummies = f_model_prod if is_mult else f_model_sum
+        return f_all_dummies(a_x, a_date, params, is_mult, **kwargs)
+
+    model_date_list = ForecastModel(
+        name,
+        len(l_model_dummy),
+        _f_model_date_list,
+        _f_init_params_date_list
+    )
+    return model_date_list
 
 # Utility functions
 

--- a/anticipy/forecast_models.py
+++ b/anticipy/forecast_models.py
@@ -14,14 +14,15 @@ initialisation parameters.
 # http://sphinx.pocoo.org/rest.html          -   Use Restructured Text for
 # docstrings
 
+import itertools
 # -- Public Imports
 import logging
+
 import numpy as np
 import pandas as pd
-import itertools
-from pandas.tseries.offsets import DateOffset
-from pandas.tseries.holiday import Holiday, AbstractHolidayCalendar,\
+from pandas.tseries.holiday import Holiday, AbstractHolidayCalendar, \
     MO, nearest_workday, GoodFriday, EasterMonday
+from pandas.tseries.offsets import DateOffset
 
 # -- Private Imports
 from anticipy import model_utils
@@ -1541,15 +1542,15 @@ class UKCalendar(AbstractHolidayCalendar):
         # Spring Bank Holiday - Last Monday in May - Same as US Memorial Day
         Holiday('Early May Bank Holiday', month=5, day=1,
                 offset=DateOffset(weekday=MO(1))
-               ),
+                ),
         Holiday('Spring Bank Holiday', month=5, day=31,
-                        offset=DateOffset(weekday=MO(-1))
-               ),
+                offset=DateOffset(weekday=MO(-1))
+                ),
         # August Bank holiday - Last Monday in August
         Holiday('August Bank Holiday', month=8, day=1,
-                        offset=DateOffset(weekday=MO(1))
-               )
-        ]
+                offset=DateOffset(weekday=MO(1))
+                )
+    ]
 
 
 def get_model_from_calendar(calendar):

--- a/anticipy/forecast_models.py
+++ b/anticipy/forecast_models.py
@@ -21,7 +21,7 @@ import logging
 import numpy as np
 import pandas as pd
 from pandas.tseries.holiday import Holiday, AbstractHolidayCalendar, \
-    MO, nearest_workday, GoodFriday, EasterMonday
+    MO, nearest_workday, GoodFriday, EasterMonday, USFederalHolidayCalendar
 from pandas.tseries.offsets import DateOffset
 
 # -- Private Imports
@@ -1581,6 +1581,7 @@ def get_model_from_calendar(calendar):
 
 
 model_ukcalendar = get_model_from_calendar(UKCalendar())
+model_uscalendar = get_model_from_calendar(USFederalHolidayCalendar())
 
 
 # Utility functions

--- a/anticipy/forecast_models.py
+++ b/anticipy/forecast_models.py
@@ -1661,6 +1661,7 @@ def get_model_from_datelist(name=None, *args):
     )
     return model_date_list
 
+
 # Utility functions
 
 def fix_params_fmodel(forecast_model, l_params_fixed):

--- a/tests/test_forecast_model.py
+++ b/tests/test_forecast_model.py
@@ -7,11 +7,11 @@ Created on 04/12/2015
 import unittest
 from argparse import Namespace
 
-from anticipy.utils_test import PandasTest
 from anticipy import forecast_models
-from anticipy.forecast_models import *
 from anticipy.forecast import normalize_df
+from anticipy.forecast_models import *
 from anticipy.model_utils import interpolate_df
+from anticipy.utils_test import PandasTest
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -258,22 +258,16 @@ class TestForecastModel(PandasTest):
                     is_mult),
                 a)
 
-        # test_model('ukcalendar', model_ukcalendar,[0.]*8,np.ones(10),
-        #            l_is_mult=[True])
-        # test_model('ukcalendar', model_ukcalendar,[0.]*8,np.zeros(10),
-        #            l_is_mult=[False])
         test_model('ukcalendar', model_ukcalendar,
-                   array_ones_in_indices(8,0),
+                   array_ones_in_indices(8, 0),
                    # First parameter changes value of New Year
-                   array_ones_in_indices(10, 0)+np.ones(10),
+                   array_ones_in_indices(10, 0) + np.ones(10),
                    l_is_mult=[True])
         test_model('ukcalendar', model_ukcalendar,
-                   array_ones_in_indices(8,0),
+                   array_ones_in_indices(8, 0),
                    # First parameter changes value of New Year
-                   array_ones_in_indices(10, 0)+np.zeros(10),
+                   array_ones_in_indices(10, 0) + np.zeros(10),
                    l_is_mult=[False])
-
-
 
     def test_forecast_model_composite(self):
         a_x = np.arange(1, 11.)

--- a/tests/test_forecast_model.py
+++ b/tests/test_forecast_model.py
@@ -997,14 +997,14 @@ class TestForecastModel(PandasTest):
                 None, None, a_date_complete))
 
     def test_get_model_from_calendar(self):
-        model_calendar=get_model_from_calendar(UKCalendar())
+        model_calendar = get_model_from_calendar(UKCalendar())
         logger_info('model_calendar:', model_calendar)
         logger_info('parameters:', model_calendar.n_params)
 
     def test_get_model_from_date_list(self):
-        model_datelist=get_model_from_datelist(
+        model_datelist = get_model_from_datelist(
             'datelist',
-            ['2018-01-01','2018-01-02'],
+            ['2018-01-01', '2018-01-02'],
             ['2018-12-25', '2019-12-25']
         )
         logger_info('model_datelist:', model_datelist)

--- a/tests/test_forecast_model.py
+++ b/tests/test_forecast_model.py
@@ -258,6 +258,23 @@ class TestForecastModel(PandasTest):
                     is_mult),
                 a)
 
+        # test_model('ukcalendar', model_ukcalendar,[0.]*8,np.ones(10),
+        #            l_is_mult=[True])
+        # test_model('ukcalendar', model_ukcalendar,[0.]*8,np.zeros(10),
+        #            l_is_mult=[False])
+        test_model('ukcalendar', model_ukcalendar,
+                   array_ones_in_indices(8,0),
+                   # First parameter changes value of New Year
+                   array_ones_in_indices(10, 0)+np.ones(10),
+                   l_is_mult=[True])
+        test_model('ukcalendar', model_ukcalendar,
+                   array_ones_in_indices(8,0),
+                   # First parameter changes value of New Year
+                   array_ones_in_indices(10, 0)+np.zeros(10),
+                   l_is_mult=[False])
+
+
+
     def test_forecast_model_composite(self):
         a_x = np.arange(1, 11.)
         a_y = np.arange(1, 11.)

--- a/tests/test_forecast_model.py
+++ b/tests/test_forecast_model.py
@@ -269,6 +269,17 @@ class TestForecastModel(PandasTest):
                    array_ones_in_indices(10, 0) + np.zeros(10),
                    l_is_mult=[False])
 
+        test_model('uscalendar', model_uscalendar,
+                   array_ones_in_indices(10, 0),
+                   # First parameter changes value of New Year
+                   array_ones_in_indices(10, 0) + np.ones(10),
+                   l_is_mult=[True])
+        test_model('uscalendar', model_uscalendar,
+                   array_ones_in_indices(10, 0),
+                   # First parameter changes value of New Year
+                   array_ones_in_indices(10, 0) + np.zeros(10),
+                   l_is_mult=[False])
+
     def test_forecast_model_composite(self):
         a_x = np.arange(1, 11.)
         a_y = np.arange(1, 11.)

--- a/tests/test_forecast_model.py
+++ b/tests/test_forecast_model.py
@@ -995,3 +995,17 @@ class TestForecastModel(PandasTest):
         self.assertTrue(
             model_season_wday.validate_input(
                 None, None, a_date_complete))
+
+    def test_get_model_from_calendar(self):
+        model_calendar=get_model_from_calendar(UKCalendar())
+        logger_info('model_calendar:', model_calendar)
+        logger_info('parameters:', model_calendar.n_params)
+
+    def test_get_model_from_date_list(self):
+        model_datelist=get_model_from_datelist(
+            'datelist',
+            ['2018-01-01','2018-01-02'],
+            ['2018-12-25', '2019-12-25']
+        )
+        logger_info('model_datelist:', model_datelist)
+        logger_info('parameters:', model_datelist.n_params)


### PR DESCRIPTION
We now have forecast_models.model_ukcalendar . I have implemented a very basic unit test, but we should add some more tests and try it with some existing datasets to make sure that it works as expected. Once we have done that, we can consider adding it as a default option, in a similar way to get_l_model_auto_season().

Also, it should be trivial to implement a new model based on pandas.tseries.USFederalHolidayCalendar... I'll add that tomorrow : 
```
get_model_from_calendar(USFederalHolidayCalendar)
```

